### PR TITLE
Performance rewrite

### DIFF
--- a/app/lib/layout/HomeFooter.tsx
+++ b/app/lib/layout/HomeFooter.tsx
@@ -10,7 +10,6 @@ const HomeFooter = () => {
             <GridItem w='100%'>
               <Stack>
                 <Heading fontSize={'md'}>INTEGRATIONS</Heading>
-                <Link>Revue</Link>
               </Stack>
             </GridItem>
             <GridItem w='100%'>

--- a/app/lib/layout/Nav.tsx
+++ b/app/lib/layout/Nav.tsx
@@ -5,8 +5,17 @@ import { slugify } from "../utils/slugify";
 import ThemeToggle from "./ThemeToggle";
 
 
+interface NavProps {
+    navItems: NavItemProps[];
+    data: any;  
+}   
 
-export default function Nav({ navItems, data }: any) {
+interface NavItemProps {
+    slug: string;
+    title: string;
+}
+
+export default function Nav({ navItems, data }: NavProps) {
 
     const buttonIconMargin = useBreakpointValue({ base: '0', md: '1', lg: '2' })
     const buttonMargin = useBreakpointValue({ base: '0', md: '0', lg: '0' })

--- a/app/lib/layout/index.tsx
+++ b/app/lib/layout/index.tsx
@@ -1,8 +1,6 @@
 import { Box, Center, Container, Flex, VStack } from "@chakra-ui/react";
 
 import Footer from "./Footer";
-import Header from "./Header";
-import HomeFooter from "./HomeFooter";
 import Nav from "./Nav";
 
 type LayoutProps = {

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,28 +1,46 @@
-import { json, LinksFunction, LoaderFunction } from "@remix-run/node";
-import { Outlet, useLoaderData, useNavigate } from "@remix-run/react";
+import { LinksFunction, LoaderFunction } from "@remix-run/node";
+import { Outlet, useLoaderData } from "@remix-run/react";
 import { CatchBoundary, Document, ErrorBoundary } from "~/lib/root";
 import globalStylesUrl from "~/lib/styles/global.css";
 import checkIndex from "./lib/notion/check-index";
 import navData from "./lib/notion/load-nav";
 import { getNotionNav } from "./lib/notion/notion-api";
 import { oAuthStrategy } from "./lib/storage/auth.server";
+import { supabaseAdmin } from "./lib/storage/supabase.server";
 import { decryptAPIKey } from "./lib/utils/encrypt-api-key";
 
-export const loader: LoaderFunction = async ({ request, params }) => {
+export const loader: LoaderFunction = async ({ request }) => {
 
   const session = await oAuthStrategy.checkSession(request);
   const { data }: any = await checkIndex(request, session);
 
-  let navItems = null
+  let navItems = data && data.nav_links || null;
+  let loggedIn = session ? true : false;
+
+  if (navItems) {
+    return {
+      loggedIn,
+      navItems,
+      data,
+      env: {
+        SUPABASE_URL: process.env.SUPABASE_URL,
+        SUPABASE_ANON_KEY: process.env.SUPABASE_ANON_KEY
+      }
+    }
+  }
 
   if (data) {
     const decryptedToken = await decryptAPIKey(data.users.notion_token.toString())
     const { nav } = await getNotionNav(data.index_page, decryptedToken)
     navItems = await navData(nav)
-    //console.log('nav items fetched from root')
-  }
 
-  let loggedIn = session ? true : false;
+    if (!data.nav_links) {
+      await supabaseAdmin
+        .from('sites')
+        .update({ nav_links: navItems })
+        .match({ site_name: data.site_name })
+    }
+  }
 
   return {
     loggedIn,

--- a/app/routes/api/refresh-blog.ts
+++ b/app/routes/api/refresh-blog.ts
@@ -1,0 +1,51 @@
+import { ActionFunction, json } from "@remix-run/node";
+import { marked } from "marked";
+import getPageLinks from "~/lib/notion/load-pageLinks";
+import { getNotionPagebyID } from "~/lib/notion/notion-api";
+import { supabaseAdmin } from "~/lib/storage/supabase.server";
+import { decryptAPIKey } from "~/lib/utils/encrypt-api-key";
+
+export const action: ActionFunction = async ({ request }) => {
+
+    // this is triggeered when user hits the loader becuase of a cache miss or revalidate
+    // need the site data to get the notion token
+    // hit all of the notion gen api endpoints to get the latest data
+    // update data in supabase
+
+    //extract bearer token from header
+    const authHeader = request.headers.get("Authorization");
+    const token = authHeader?.split(" ")[1];
+    
+    if(token !== process.env.AUTH_BEARER_TOKEN){
+        return json({ status: 401, error: "unauthorized" });
+    }
+
+    const url = new URL(request.url);
+    const site = url.searchParams.get("site");
+
+    const { data, error } = await supabaseAdmin
+        .from('sites')
+        .select('*, users(notion_token)')
+        .or(`site_name.eq.${site}`)
+        .single()
+
+    try {
+        const decryptedToken = await decryptAPIKey(data.users.notion_token.toString())
+        const content = await getNotionPagebyID(data.index_page, decryptedToken)
+        const html = marked(content.markdown);
+        const pageObject = content.pageObject
+        const pageLinks = await getPageLinks(pageObject, decryptedToken)
+
+        await supabaseAdmin
+            .from('sites')
+            .update({ home_html: html, page_links: pageLinks, page_object: pageObject, db_page: pageObject?.posts })
+            .match({ site_name: site })
+
+        console.log("finished refresh blog", site)
+
+        return json({ status: 200 })
+    } catch (error) {
+        console.error(error);
+        return json({ status: 500, error });
+    }
+};

--- a/app/routes/blog.$slug.tsx
+++ b/app/routes/blog.$slug.tsx
@@ -4,7 +4,6 @@ import { json, LinksFunction, LoaderFunction, MetaFunction, redirect } from "@re
 import { useLoaderData, Link as RemixLink, useLocation } from "@remix-run/react";
 import { marked } from "marked";
 import TimeAgo from "timeago-react";
-import RevueForm from "~/lib/components/revueForm";
 import { getSingleBlogPost } from "~/lib/notion/notion-api";
 import { supabaseAdmin } from "~/lib/storage/supabase.server";
 import { decryptAPIKey } from "~/lib/utils/encrypt-api-key";
@@ -201,9 +200,6 @@ export default function Slug() {
                         </Flex>
                     </Flex>
                 </Prose>
-            </Flex>
-            <Flex justify={'center'} pt={10} pb={10} display={data.revue_profile ? 'flex' : 'none'}>
-                <RevueForm revue_profile={data.revue_profile} />
             </Flex>
         </Stack>
     )


### PR DESCRIPTION
Introduce Supabase as a cache for nav and home route.

- Site on first gen hits the Notion API and saves raw results to Supabase site record.
- On site refresh site will either HIT vercel cache or return supabase record.
- Every stale-while-revalidate will trigger an async refresh-blog to sync with Notion.